### PR TITLE
Update API to reflect clearer function identifier

### DIFF
--- a/lib/alephant/sequencer/sequencer.rb
+++ b/lib/alephant/sequencer/sequencer.rb
@@ -25,7 +25,7 @@ module Alephant
         @exists || @sequence_table.sequence_exists(ident)
       end
 
-      def sequence(msg, &block)
+      def validate(msg, &block)
         last_seen_id = get_last_seen
         sequential = ((last_seen_id || 0) < Sequencer.sequence_id_from(msg, jsonpath))
 

--- a/spec/sequencer_spec.rb
+++ b/spec/sequencer_spec.rb
@@ -40,7 +40,7 @@ describe Alephant::Sequencer do
 
     end
 
-    describe "#sequence(msg, &block)" do
+    describe "#validate(msg, &block)" do
       let(:message) do
         m = double()
         m.stub(:body)
@@ -71,7 +71,7 @@ describe Alephant::Sequencer do
 
       it "should call the passed block with msg" do
         subject = Alephant::Sequencer::Sequencer.new(sequence_table, ident, jsonpath)
-        subject.sequence(message, &a_proc)
+        subject.validate(message, &a_proc)
       end
 
       context "last_seen_id is nil" do
@@ -93,7 +93,7 @@ describe Alephant::Sequencer do
             .with(message, nil)
 
           subject = Alephant::Sequencer::Sequencer.new(sequence_table, ident, jsonpath)
-          subject.sequence(message, &a_proc)
+          subject.validate(message, &a_proc)
         end
       end
 
@@ -115,7 +115,7 @@ describe Alephant::Sequencer do
             .should_not_receive(:set_last_seen)
 
           subject = Alephant::Sequencer::Sequencer.new(sequence_table, ident, jsonpath)
-          subject.sequence(message, &a_proc)
+          subject.validate(message, &a_proc)
         end
       end
 
@@ -138,7 +138,7 @@ describe Alephant::Sequencer do
             .should_not_receive(:set_last_seen)
 
           subject = Alephant::Sequencer::Sequencer.new(sequence_table, ident, jsonpath)
-          subject.sequence(message, &a_proc)
+          subject.validate(message, &a_proc)
         end
 
         context "keep_all is false" do
@@ -150,7 +150,7 @@ describe Alephant::Sequencer do
               jsonpath,
               keep_all
             )
-            subject.sequence(message, &an_uncalled_proc)
+            subject.validate(message, &an_uncalled_proc)
           end
         end
       end
@@ -174,7 +174,7 @@ describe Alephant::Sequencer do
             .with(message, stubbed_last_seen)
 
           subject = Alephant::Sequencer::Sequencer.new(sequence_table, ident, jsonpath)
-          subject.sequence(message, &a_proc)
+          subject.validate(message, &a_proc)
         end
       end
     end


### PR DESCRIPTION
![getinsertpic.com](http://media2.giphy.com/media/FVBLiFGpKEgKs/200.gif)
_^ my response to bad function names_
## Problem

The `sequence` function does not accurately reflect what it does, which in this instance is to validate that the provided message is sequential before attempting to update the "last seen" number and proceeding to write the renderered content.
## Solution

Rename the function as seen in this PR.

> Note: this PR requires a change to the `alephant-publisher-queue` https://github.com/BBC-News/alephant-publisher-queue/pull/4
