### PR TITLE
Add cache to sequencer

### DIFF
--- a/alephant-sequencer.gemspec
+++ b/alephant-sequencer.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'alephant/sequencer/version'
+require "alephant/sequencer/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "alephant-sequencer"
@@ -28,8 +28,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-remote"
   spec.add_development_dependency "pry-nav"
 
-  spec.add_runtime_dependency 'aws-sdk', '~> 1.0'
-  spec.add_runtime_dependency 'alephant-logger'
-  spec.add_runtime_dependency 'alephant-support'
-  spec.add_runtime_dependency 'jsonpath'
+  spec.add_runtime_dependency "aws-sdk", "~> 1.0"
+  spec.add_runtime_dependency "alephant-logger"
+  spec.add_runtime_dependency "alephant-support"
+  spec.add_runtime_dependency "jsonpath"
+  spec.add_runtime_dependency "dalli-elasticache"
 end

--- a/lib/alephant/sequencer.rb
+++ b/lib/alephant/sequencer.rb
@@ -7,10 +7,18 @@ module Alephant
   module Sequencer
     @@sequence_tables = {}
 
-    def self.create(table_name, ident, jsonpath = nil, keep_all = true, config = {})
+    def self.create(table_name, opts = {})
+      defaults = {
+        :jsonpath => nil,
+        :keep_all => true,
+        :config => {}
+      }
+
+      opts = defaults.merge(opts)
+
       @@sequence_tables[table_name] ||= SequenceTable.new(table_name)
-      @cache ||= SequenceCache.new(config)
-      Sequencer.new(@@sequence_tables[table_name], ident, jsonpath, keep_all, @cache)
+      @cache ||= SequenceCache.new(opts[:config])
+      Sequencer.new(@@sequence_tables[table_name], opts[:ident], opts[:jsonpath], opts[:keep_all], @cache)
     end
 
   end

--- a/lib/alephant/sequencer.rb
+++ b/lib/alephant/sequencer.rb
@@ -14,12 +14,18 @@ module Alephant
         :config => {}
       }
 
-      opts = defaults.merge(opts)
+      opts = defaults.merge(opts).tap do |opts|
+        opts[:cache] = self.cache(opts[:config])
+      end
 
       @@sequence_tables[table_name] ||= SequenceTable.new(table_name)
-      @cache ||= SequenceCache.new(opts[:config])
-      Sequencer.new(@@sequence_tables[table_name], opts[:ident], opts[:jsonpath], opts[:keep_all], @cache)
+      Sequencer.new(@@sequence_tables[table_name], opts)
     end
 
+    private
+
+    def self.cache(config)
+      @cache ||= SequenceCache.new(config)
+    end
   end
 end

--- a/lib/alephant/sequencer.rb
+++ b/lib/alephant/sequencer.rb
@@ -1,14 +1,16 @@
 require "alephant/sequencer/version"
 require "alephant/sequencer/sequencer"
 require "alephant/sequencer/sequence_table"
+require "alephant/sequencer/sequence_cache"
 
 module Alephant
   module Sequencer
     @@sequence_tables = {}
 
-    def self.create(table_name, ident, jsonpath = nil, keep_all = true)
+    def self.create(table_name, ident, jsonpath = nil, keep_all = true, config = {})
       @@sequence_tables[table_name] ||= SequenceTable.new(table_name)
-      Sequencer.new(@@sequence_tables[table_name], ident, jsonpath, keep_all)
+      @cache ||= SequenceCache.new(config)
+      Sequencer.new(@@sequence_tables[table_name], ident, jsonpath, keep_all, @cache)
     end
 
   end

--- a/lib/alephant/sequencer/sequence_cache.rb
+++ b/lib/alephant/sequencer/sequence_cache.rb
@@ -1,0 +1,69 @@
+require "dalli-elasticache"
+require "alephant/logger"
+
+module Alephant
+  module Sequencer
+    class SequenceCache
+      include Logger
+
+      attr_reader :config
+
+      DEFAULT_TTL  = 5
+
+      def initialize(config={})
+        @config = config
+
+        unless config_endpoint.nil?
+          @elasticache ||= ::Dalli::ElastiCache.new(config_endpoint, { :expires_in => ttl })
+          @client ||= @elasticache.client
+        else
+          logger.debug "Alephant::SequenceCache::#initialize: No config endpoint, NullClient used"
+          logger.metric "NoConfigEndpoint"
+          @client = NullClient.new
+        end
+      end
+
+      def get(key, &block)
+        begin
+          versioned_key = versioned key
+          result = @client.get versioned_key
+          logger.info "Alephant::SequenceCache#get key: #{versioned_key} - #{result ? 'hit' : 'miss'}"
+          logger.metric "GetKeyMiss" unless result
+          result ? result : set(key, block.call)
+        rescue StandardError => e
+          block.call if block_given?
+        end
+      end
+
+      def set(key, value, ttl = nil)
+        value.tap { |o| @client.set(versioned(key), o, ttl) }
+      end
+
+      private
+
+      def config_endpoint
+        config["elasticache_config_endpoint"]
+      end
+
+      def ttl
+        config["elasticache_ttl"] || DEFAULT_TTL
+      end
+
+      def versioned(key)
+        [key, cache_version].compact.join("_")
+      end
+
+      def cache_version
+        config["elasticache_cache_version"]
+      end
+    end
+
+    class NullClient
+      def get(key); end
+
+      def set(key, value, ttl = nil)
+        value
+      end
+    end
+  end
+end

--- a/lib/alephant/sequencer/sequence_cache.rb
+++ b/lib/alephant/sequencer/sequence_cache.rb
@@ -31,7 +31,7 @@ module Alephant
           logger.metric "GetKeyMiss" unless result
           result ? result : set(key, block.call)
         rescue StandardError => e
-          block.call if block_given?
+          block.call
         end
       end
 

--- a/lib/alephant/sequencer/sequencer.rb
+++ b/lib/alephant/sequencer/sequencer.rb
@@ -7,19 +7,19 @@ module Alephant
       include Logger
       attr_reader :ident, :jsonpath, :keep_all, :cache
 
-      def initialize(sequence_table, id, sequence_path, keep_all, cache)
+      def initialize(sequence_table, opts = {})
         @sequence_table = sequence_table
 
-        @cache    = cache
-        @keep_all = keep_all
-        @ident    = id
+        @cache    = opts[:cache]
+        @keep_all = opts[:keep_all]
+        @ident    = opts[:id]
         @exists   = exists?
-        @jsonpath = sequence_path
+        @jsonpath = opts[:jsonpath]
         logger.info(
           "event"         => "SequencerInitialized",
           "sequenceTable" => sequence_table,
-          "jsonPath"      => sequence_path,
-          "id"            => id,
+          "jsonPath"      => @jsonpath,
+          "id"            => @ident,
           "method"        => "#{self.class}#initialize"
         )
       end

--- a/lib/alephant/sequencer/sequencer.rb
+++ b/lib/alephant/sequencer/sequencer.rb
@@ -12,9 +12,9 @@ module Alephant
 
         @cache    = cache
         @keep_all = keep_all
+        @ident    = id
         @exists   = exists?
         @jsonpath = sequence_path
-        @ident    = id
         logger.info(
           "event"         => "SequencerInitialized",
           "sequenceTable" => sequence_table,

--- a/spec/sequencer_spec.rb
+++ b/spec/sequencer_spec.rb
@@ -7,6 +7,14 @@ describe Alephant::Sequencer do
   let(:keep_all) { true }
   let(:config) { { "elasticache_config_endpoint" => "/foo" } }
   let(:cache) { Alephant::Sequencer::SequenceCache.new(config) }
+  let(:opts) {
+    {
+      :id => ident,
+      :jsonpath => jsonpath,
+      :keep_all => keep_all,
+      :cache => cache
+    }
+  }
 
   describe ".create" do
     it "should return a Sequencer" do
@@ -17,7 +25,7 @@ describe Alephant::Sequencer do
       expect_any_instance_of(Alephant::Sequencer::SequenceTable).to receive(:sequence_exists)
 
       opts = {
-        :ident => ident,
+        :id => ident,
         :jsonpath => jsonpath,
         :keep_all => keep_all,
         :config => config
@@ -30,7 +38,7 @@ describe Alephant::Sequencer do
       expect_any_instance_of(Alephant::Sequencer::SequenceTable).to receive(:sequence_exists)
 
       opts = {
-        :ident => ident
+        :id => ident
       }
 
       instance = subject.create(:table_name, opts)
@@ -49,7 +57,7 @@ describe Alephant::Sequencer do
 
     describe "#initialize" do
       subject (:instance) {
-        described_class.new(sequence_table, ident, jsonpath, keep_all, cache)
+        described_class.new(sequence_table, opts)
       }
 
       it "sets @jsonpath, @ident" do
@@ -91,7 +99,7 @@ describe Alephant::Sequencer do
       let(:stubbed_seen_low)  { 1 }
 
       subject (:instance) {
-        described_class.new(sequence_table, ident, jsonpath, keep_all, cache)
+        described_class.new(sequence_table, opts)
       }
 
       it "should call the passed block" do
@@ -180,13 +188,14 @@ describe Alephant::Sequencer do
           it "should not call the passed block with msg" do
             expect(sequence_table).to receive(:sequence_exists)
 
-            instance = described_class.new(
-              sequence_table,
-              ident,
-              jsonpath,
-              keep_all,
-              cache
-            )
+            opts = {
+              :id => ident,
+              :jsonpath => jsonpath,
+              :keep_all => keep_all,
+              :cache => cache
+            }
+
+            instance = described_class.new(sequence_table, opts)
             instance.validate(message, &an_uncalled_proc)
           end
         end
@@ -238,7 +247,7 @@ describe Alephant::Sequencer do
 
     describe "#get_last_seen" do
       subject (:instance) {
-        described_class.new(sequence_table, ident, jsonpath, keep_all, cache)
+        described_class.new(sequence_table, opts)
       }
 
       it "returns sequence_table.sequence_for(ident)" do
@@ -270,7 +279,7 @@ describe Alephant::Sequencer do
       end
 
       subject (:instance) {
-        described_class.new(sequence_table, ident, jsonpath, keep_all, cache)
+        described_class.new(sequence_table, opts)
       }
 
       it "calls update_sequence_id(ident, last_seen)" do
@@ -308,7 +317,7 @@ describe Alephant::Sequencer do
       end
 
       subject (:instance) {
-        described_class.new(sequence_table, ident, jsonpath, keep_all, cache)
+        described_class.new(sequence_table, opts)
       }
 
       context "jsonpath = '$.sequence_id'" do
@@ -354,7 +363,7 @@ describe Alephant::Sequencer do
 
     describe "#truncate!" do
       subject (:instance) {
-        described_class.new(sequence_table, ident, jsonpath, keep_all, cache)
+        described_class.new(sequence_table, opts)
       }
 
       it "verify SequenceTable#truncate!" do

--- a/spec/sequencer_spec.rb
+++ b/spec/sequencer_spec.rb
@@ -15,7 +15,31 @@ describe Alephant::Sequencer do
 
       expect_any_instance_of(Alephant::Sequencer::SequenceTable).to receive(:initialize)
       expect_any_instance_of(Alephant::Sequencer::SequenceTable).to receive(:sequence_exists)
-      expect(subject.create(:table_name, ident, jsonpath, keep_all, config)).to be_a Alephant::Sequencer::Sequencer
+
+      opts = {
+        :ident => ident,
+        :jsonpath => jsonpath,
+        :keep_all => keep_all,
+        :config => config
+      }
+
+      expect(subject.create(:table_name, opts)).to be_a Alephant::Sequencer::Sequencer
+    end
+
+    it "should use default opts if options not provided" do
+      expect_any_instance_of(Alephant::Sequencer::SequenceTable).to receive(:sequence_exists)
+
+      opts = {
+        :ident => ident
+      }
+
+      instance = subject.create(:table_name, opts)
+
+      expect(instance).to be_a Alephant::Sequencer::Sequencer
+      expect(instance.ident).to eq(ident)
+      expect(instance.jsonpath).to eq(nil)
+      expect(instance.keep_all).to eq(true)
+      expect(instance.cache).to be_a(Alephant::Sequencer::SequenceCache)
     end
   end
 


### PR DESCRIPTION
Add cache to sequencer

https://jira.dev.bbc.co.uk/browse/CONNPOL-2821

This is the second part of the DynamoDB caching strategy.

![](https://media.giphy.com/media/l41lFw057lAJQMwg0/giphy.gif)
