### PR TITLE
Adjust Sequencer Cache TTL

### DIFF
--- a/lib/alephant/sequencer/sequence_cache.rb
+++ b/lib/alephant/sequencer/sequence_cache.rb
@@ -8,7 +8,7 @@ module Alephant
 
       attr_reader :config
 
-      DEFAULT_TTL  = 5
+      DEFAULT_TTL  = 2
 
       def initialize(config={})
         @config = config
@@ -46,7 +46,7 @@ module Alephant
       end
 
       def ttl
-        config["elasticache_ttl"] || DEFAULT_TTL
+        config["sequencer_elasticache_ttl"] || DEFAULT_TTL
       end
 
       def versioned(key)


### PR DESCRIPTION
Adjust Sequencer Cache TTL:
* Make default TTL shorter - now 2 seconds
* Change config variable name, so we can use different cache values for different caches

![](https://media.giphy.com/media/xT9DPiF2FOAvxvpNXG/giphy.gif)