### PR TITLE
Fix cache config to allow symbols as keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 Gemfile.lock
 .rspec
 *.gem
+*.log
 
 /pkg
 /tmp

--- a/Guardfile
+++ b/Guardfile
@@ -1,6 +1,6 @@
 guard 'rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/.+\.rb$})
-  watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
-  watch('spec/spec_helper.rb')                        { "spec" }
+  watch(%r{^spec/support/(.+)\.rb$})                  { 'spec' }
+  watch('spec/spec_helper.rb')                        { 'spec' }
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-$:.unshift File.join(File.dirname(__FILE__), 'lib')
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), 'lib')
 
 require 'bundler/gem_tasks'
 require 'rake/rspec'
 
-task :default => :spec
+task default: :spec

--- a/lib/alephant/sequencer.rb
+++ b/lib/alephant/sequencer.rb
@@ -1,7 +1,7 @@
-require "alephant/sequencer/version"
-require "alephant/sequencer/sequencer"
-require "alephant/sequencer/sequence_table"
-require "alephant/sequencer/sequence_cache"
+require 'alephant/sequencer/version'
+require 'alephant/sequencer/sequencer'
+require 'alephant/sequencer/sequence_table'
+require 'alephant/sequencer/sequence_cache'
 
 module Alephant
   module Sequencer
@@ -9,13 +9,13 @@ module Alephant
 
     def self.create(table_name, opts = {})
       defaults = {
-        :jsonpath => nil,
-        :keep_all => true,
-        :config => {}
+        jsonpath: nil,
+        keep_all: true,
+        config:   {}
       }
 
       opts = defaults.merge(opts).tap do |opts|
-        opts[:cache] = self.cache(opts[:config])
+        opts[:cache] = cache(opts[:config])
       end
 
       @@sequence_tables[table_name] ||= SequenceTable.new(table_name)

--- a/lib/alephant/sequencer/sequence_cache.rb
+++ b/lib/alephant/sequencer/sequence_cache.rb
@@ -42,11 +42,11 @@ module Alephant
       private
 
       def config_endpoint
-        config["elasticache_config_endpoint"]
+        config[:elasticache_config_endpoint] || config["elasticache_config_endpoint"]
       end
 
       def ttl
-        config["sequencer_elasticache_ttl"] || DEFAULT_TTL
+        config[:sequencer_elasticache_ttl] || config["sequencer_elasticache_ttl"] || DEFAULT_TTL
       end
 
       def versioned(key)
@@ -54,7 +54,7 @@ module Alephant
       end
 
       def cache_version
-        config["elasticache_cache_version"]
+        config[:elasticache_cache_version] || config["elasticache_cache_version"]
       end
     end
 

--- a/lib/alephant/sequencer/sequence_cache.rb
+++ b/lib/alephant/sequencer/sequence_cache.rb
@@ -1,5 +1,5 @@
-require "dalli-elasticache"
-require "alephant/logger"
+require 'dalli-elasticache'
+require 'alephant/logger'
 
 module Alephant
   module Sequencer
@@ -8,31 +8,29 @@ module Alephant
 
       attr_reader :config
 
-      DEFAULT_TTL  = 2
+      DEFAULT_TTL = 2
 
-      def initialize(config={})
+      def initialize(config = {})
         @config = config
 
-        unless config_endpoint.nil?
-          @elasticache ||= ::Dalli::ElastiCache.new(config_endpoint, { :expires_in => ttl })
-          @client ||= @elasticache.client
-        else
-          logger.debug "Alephant::SequenceCache::#initialize: No config endpoint, NullClient used"
-          logger.metric "NoConfigEndpoint"
+        if config_endpoint.nil?
+          logger.debug 'Alephant::SequenceCache::#initialize: No config endpoint, NullClient used'
+          logger.metric 'NoConfigEndpoint'
           @client = NullClient.new
+        else
+          @elasticache ||= ::Dalli::ElastiCache.new(config_endpoint, expires_in: ttl)
+          @client ||= @elasticache.client
         end
       end
 
-      def get(key, &block)
-        begin
-          versioned_key = versioned key
-          result = @client.get versioned_key
-          logger.info "Alephant::SequenceCache#get key: #{versioned_key} - #{result ? 'hit' : 'miss'}"
-          logger.metric "GetKeyMiss" unless result
-          result ? result : set(key, block.call)
-        rescue StandardError => e
-          block.call
-        end
+      def get(key)
+        versioned_key = versioned key
+        result = @client.get versioned_key
+        logger.info "Alephant::SequenceCache#get key: #{versioned_key} - #{result ? 'hit' : 'miss'}"
+        logger.metric 'GetKeyMiss' unless result
+        result ? result : set(key, yield)
+      rescue StandardError => e
+        yield
       end
 
       def set(key, value, ttl = nil)
@@ -42,26 +40,26 @@ module Alephant
       private
 
       def config_endpoint
-        config[:elasticache_config_endpoint] || config["elasticache_config_endpoint"]
+        config[:elasticache_config_endpoint] || config['elasticache_config_endpoint']
       end
 
       def ttl
-        config[:sequencer_elasticache_ttl] || config["sequencer_elasticache_ttl"] || DEFAULT_TTL
+        config[:sequencer_elasticache_ttl] || config['sequencer_elasticache_ttl'] || DEFAULT_TTL
       end
 
       def versioned(key)
-        [key, cache_version].compact.join("_")
+        [key, cache_version].compact.join('_')
       end
 
       def cache_version
-        config[:elasticache_cache_version] || config["elasticache_cache_version"]
+        config[:elasticache_cache_version] || config['elasticache_cache_version']
       end
     end
 
     class NullClient
       def get(key); end
 
-      def set(key, value, ttl = nil)
+      def set(_key, value, _ttl = nil)
         value
       end
     end

--- a/lib/alephant/sequencer/sequence_table.rb
+++ b/lib/alephant/sequencer/sequence_table.rb
@@ -1,9 +1,9 @@
-require "aws-sdk"
-require "thread"
-require "timeout"
+require 'aws-sdk'
+require 'thread'
+require 'timeout'
 
-require "alephant/logger"
-require "alephant/support/dynamodb/table"
+require 'alephant/logger'
+require 'alephant/support/dynamodb/table'
 
 module Alephant
   module Sequencer
@@ -18,13 +18,11 @@ module Alephant
       end
 
       def sequence_exists(ident)
-        if ident.nil?
-          return false
-        end
+        return false if ident.nil?
 
-        !(client.get_item(
+        !client.get_item(
           item_payload(ident)
-        ).length == 0)
+        ).empty?
       end
 
       def sequence_for(ident)
@@ -32,62 +30,58 @@ module Alephant
           item_payload(ident)
         )
 
-        data.length > 0 ? data[:item]["value"][:n].to_i : 0
+        !data.empty? ? data[:item]['value'][:n].to_i : 0
       end
 
       def update_sequence_id(ident, value, last_seen_check = nil)
-        begin
-          current_sequence = last_seen_check.nil? ? sequence_for(ident) : last_seen_check
+        current_sequence = last_seen_check.nil? ? sequence_for(ident) : last_seen_check
 
-          dynamo_response = @mutex.synchronize do
-            client.put_item({
-              :table_name => table_name,
-              :item => {
-                'key' => {
-                  'S' => ident
-                },
-                'value' => {
-                  'N' => value.to_s
-                }
-              },
-              :expected => {
-                'key' => {
-                  :comparison_operator => 'NULL'
-                },
-                'value' => {
-                  :comparison_operator => 'GE',
-                  :attribute_value_list => [
-                    { 'N' => current_sequence.to_s }
-                  ]
-                }
-              },
-              :conditional_operator => 'OR'
-            })
-          end
-
-          logger.metric("SequencerFailedConditionalChecks", :value => 0)
-          logger.info(
-            "event"  => "SequenceIdUpdated",
-            "id"     => ident,
-            "value"  => value,
-            "method" => "#{self.class}#update_sequence_id"
-          )
-
-          dynamo_response
-
-        rescue AWS::DynamoDB::Errors::ConditionalCheckFailedException
-          logger.metric "SequencerFailedConditionalChecks"
-          logger.error(
-            "event"                => "DynamoDBConditionalCheckFailed",
-            "newSequenceValue"     => value,
-            "currentSequenceValue" => current_sequence,
-            "id"                   => ident,
-            "class"                => e.class,
-            "message"              => e.message,
-            "backtrace"            => e.backtrace.join("\n"),
-            "method"               => "#{self.class}#update_sequence_id"
-          )
+        dynamo_response = @mutex.synchronize do
+          client.put_item(table_name:           table_name,
+                          item:                 {
+                            'key'   => {
+                              'S' => ident
+                            },
+                            'value' => {
+                              'N' => value.to_s
+                            }
+                          },
+                          expected:             {
+                            'key'   => {
+                              comparison_operator: 'NULL'
+                            },
+                            'value' => {
+                              comparison_operator:  'GE',
+                              attribute_value_list: [
+                                { 'N' => current_sequence.to_s }
+                              ]
+                            }
+                          },
+                          conditional_operator: 'OR')
         end
+
+        logger.metric('SequencerFailedConditionalChecks', value: 0)
+        logger.info(
+          'event'  => 'SequenceIdUpdated',
+          'id'     => ident,
+          'value'  => value,
+          'method' => "#{self.class}#update_sequence_id"
+        )
+
+        dynamo_response
+
+      rescue AWS::DynamoDB::Errors::ConditionalCheckFailedException
+        logger.metric 'SequencerFailedConditionalChecks'
+        logger.error(
+          'event'                => 'DynamoDBConditionalCheckFailed',
+          'newSequenceValue'     => value,
+          'currentSequenceValue' => current_sequence,
+          'id'                   => ident,
+          'class'                => e.class,
+          'message'              => e.message,
+          'backtrace'            => e.backtrace.join("\n"),
+          'method'               => "#{self.class}#update_sequence_id"
+        )
       end
 
       def delete_item!(ident)
@@ -100,15 +94,14 @@ module Alephant
 
       def item_payload(ident)
         {
-          :table_name => table_name,
-          :key => {
+          table_name: table_name,
+          key:        {
             'key' => {
               'S' => ident.to_s
             }
           }
         }
       end
-
     end
   end
 end

--- a/lib/alephant/sequencer/sequencer.rb
+++ b/lib/alephant/sequencer/sequencer.rb
@@ -1,5 +1,5 @@
-require "jsonpath"
-require "alephant/logger"
+require 'jsonpath'
+require 'alephant/logger'
 
 module Alephant
   module Sequencer
@@ -16,11 +16,11 @@ module Alephant
         @exists   = exists?
         @jsonpath = opts[:jsonpath]
         logger.info(
-          "event"         => "SequencerInitialized",
-          "sequenceTable" => sequence_table,
-          "jsonPath"      => @jsonpath,
-          "id"            => @ident,
-          "method"        => "#{self.class}#initialize"
+          'event'         => 'SequencerInitialized',
+          'sequenceTable' => sequence_table,
+          'jsonPath'      => @jsonpath,
+          'id'            => @ident,
+          'method'        => "#{self.class}#initialize"
         )
       end
 
@@ -34,21 +34,21 @@ module Alephant
         end
       end
 
-      def validate(msg, &block)
+      def validate(msg)
         last_seen_id = get_last_seen
         sequential = ((last_seen_id || 0) < Sequencer.sequence_id_from(msg, jsonpath))
 
-        block.call if (sequential || keep_all)
+        yield if sequential || keep_all
 
         if sequential
           set_last_seen(msg, last_seen_id)
         else
-          logger.metric "SequencerNonSequentialMessageCount"
+          logger.metric 'SequencerNonSequentialMessageCount'
           logger.info(
-            "event"      => "NonSequentialMessageReceived",
-            "id"         => ident,
-            "lastSeenId" => last_seen_id,
-            "method"     => "#{self.class}#validate"
+            'event'      => 'NonSequentialMessageReceived',
+            'id'         => ident,
+            'lastSeenId' => last_seen_id,
+            'method'     => "#{self.class}#validate"
           )
         end
       end
@@ -57,9 +57,9 @@ module Alephant
         @exists = false
         @sequence_table.delete_item!(ident).tap do
           logger.info(
-            "event"  => "SequenceIdDeleted",
-            "id"     => ident,
-            "method" => "#{self.class}#delete!"
+            'event'  => 'SequenceIdDeleted',
+            'id'     => ident,
+            'method' => "#{self.class}#delete!"
           )
         end
       end

--- a/lib/alephant/sequencer/version.rb
+++ b/lib/alephant/sequencer/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Sequencer
-    VERSION = "3.0.2"
+    VERSION = '3.0.3'
   end
 end

--- a/lib/alephant/sequencer/version.rb
+++ b/lib/alephant/sequencer/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Sequencer
-    VERSION = '3.0.3'
+    VERSION = '3.0.3'.freeze
   end
 end

--- a/spec/sequencer_spec.rb
+++ b/spec/sequencer_spec.rb
@@ -1,23 +1,23 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Alephant::Sequencer do
   let(:ident)    { :ident }
-  let(:jsonpath) { "$.sequence_id" }
+  let(:jsonpath) { '$.sequence_id' }
   let(:sequence_table) { double(Alephant::Sequencer::SequenceTable) }
   let(:keep_all) { true }
-  let(:config) { { "elasticache_config_endpoint" => "/foo" } }
+  let(:config) { { 'elasticache_config_endpoint' => '/foo' } }
   let(:cache) { Alephant::Sequencer::SequenceCache.new(config) }
-  let(:opts) {
+  let(:opts) do
     {
-      :id => ident,
-      :jsonpath => jsonpath,
-      :keep_all => keep_all,
-      :cache => cache
+      id:       ident,
+      jsonpath: jsonpath,
+      keep_all: keep_all,
+      cache:    cache
     }
-  }
+  end
 
-  describe ".create" do
-    it "should return a Sequencer" do
+  describe '.create' do
+    it 'should return a Sequencer' do
       expect_any_instance_of(Dalli::ElastiCache).to receive(:initialize)
       expect_any_instance_of(Dalli::ElastiCache).to receive(:client).and_return(Dalli::Client.new)
 
@@ -25,20 +25,20 @@ describe Alephant::Sequencer do
       expect_any_instance_of(Alephant::Sequencer::SequenceTable).to receive(:sequence_exists)
 
       opts = {
-        :id => ident,
-        :jsonpath => jsonpath,
-        :keep_all => keep_all,
-        :config => config
+        id:       ident,
+        jsonpath: jsonpath,
+        keep_all: keep_all,
+        config:   config
       }
 
       expect(subject.create(:table_name, opts)).to be_a Alephant::Sequencer::Sequencer
     end
 
-    it "should use default opts if options not provided" do
+    it 'should use default opts if options not provided' do
       expect_any_instance_of(Alephant::Sequencer::SequenceTable).to receive(:sequence_exists)
 
       opts = {
-        :id => ident
+        id: ident
       }
 
       instance = subject.create(:table_name, opts)
@@ -52,15 +52,15 @@ describe Alephant::Sequencer do
   end
 
   describe Alephant::Sequencer::Sequencer do
-    let(:data)      { double() }
+    let(:data)      { double }
     let(:last_seen) { 42 }
 
-    describe "#initialize" do
-      subject (:instance) {
+    describe '#initialize' do
+      subject (:instance) do
         described_class.new(sequence_table, opts)
-      }
+      end
 
-      it "sets @jsonpath, @ident" do
+      it 'sets @jsonpath, @ident' do
         expect(sequence_table).to receive(:sequence_exists)
 
         expect_any_instance_of(Dalli::ElastiCache).to receive(:initialize)
@@ -70,26 +70,25 @@ describe Alephant::Sequencer do
         expect(instance.ident).to eq(ident)
         expect(instance.keep_all).to eq(true)
       end
-
     end
 
-    describe "#validate" do
-      let(:message) { double() }
+    describe '#validate' do
+      let(:message) { double }
 
       let(:an_uncalled_proc) do
-        a_block = double()
+        a_block = double
         expect(a_block).to_not receive(:called).with(message)
 
-        Proc.new do |msg|
+        proc do |msg|
           a_block.called(msg)
         end
       end
 
       let(:a_proc) do
-        a_block = double()
+        a_block = double
         expect(a_block).to receive(:called)
 
-        Proc.new do
+        proc do
           a_block.called
         end
       end
@@ -98,11 +97,11 @@ describe Alephant::Sequencer do
       let(:stubbed_seen_high) { 3 }
       let(:stubbed_seen_low)  { 1 }
 
-      subject (:instance) {
+      subject (:instance) do
         described_class.new(sequence_table, opts)
-      }
+      end
 
-      it "should call the passed block" do
+      it 'should call the passed block' do
         expect(sequence_table).to receive(:sequence_exists)
         expect(sequence_table).to receive(:sequence_for).with(ident)
 
@@ -117,7 +116,7 @@ describe Alephant::Sequencer do
         instance.validate(message, &a_proc)
       end
 
-      context "last_seen_id is nil" do
+      context 'last_seen_id is nil' do
         before(:each) do
           expect_any_instance_of(described_class).to receive(:get_last_seen).and_return(nil)
 
@@ -130,7 +129,7 @@ describe Alephant::Sequencer do
           expect_any_instance_of(Dalli::Client).to receive(:set)
         end
 
-        it "should not call set_last_seen" do
+        it 'should not call set_last_seen' do
           expect_any_instance_of(described_class).to receive(:set_last_seen).with(message, nil)
 
           expect(sequence_table).to receive(:sequence_exists)
@@ -139,7 +138,7 @@ describe Alephant::Sequencer do
         end
       end
 
-      context "last_seen_id == sequence_id_from(msg)" do
+      context 'last_seen_id == sequence_id_from(msg)' do
         before(:each) do
           expect_any_instance_of(described_class).to receive(:get_last_seen).and_return(stubbed_last_seen)
 
@@ -152,7 +151,7 @@ describe Alephant::Sequencer do
           expect_any_instance_of(Dalli::Client).to receive(:set)
         end
 
-        it "should not call set_last_seen(msg, last_seen_id)" do
+        it 'should not call set_last_seen(msg, last_seen_id)' do
           expect_any_instance_of(described_class).to_not receive(:set_last_seen)
 
           expect(sequence_table).to receive(:sequence_exists)
@@ -161,7 +160,7 @@ describe Alephant::Sequencer do
         end
       end
 
-      context "last_seen_id > sequence_id_from(msg)" do
+      context 'last_seen_id > sequence_id_from(msg)' do
         before(:each) do
           expect_any_instance_of(described_class).to receive(:get_last_seen).and_return(stubbed_last_seen)
 
@@ -174,7 +173,7 @@ describe Alephant::Sequencer do
           expect_any_instance_of(Dalli::Client).to receive(:set)
         end
 
-        it "should not call set_last_seen" do
+        it 'should not call set_last_seen' do
           expect_any_instance_of(described_class).to_not receive(:set_last_seen)
 
           expect(sequence_table).to receive(:sequence_exists)
@@ -182,17 +181,17 @@ describe Alephant::Sequencer do
           instance.validate(message, &a_proc)
         end
 
-        context "keep_all is false" do
+        context 'keep_all is false' do
           let(:keep_all) { false }
 
-          it "should not call the passed block with msg" do
+          it 'should not call the passed block with msg' do
             expect(sequence_table).to receive(:sequence_exists)
 
             opts = {
-              :id => ident,
-              :jsonpath => jsonpath,
-              :keep_all => keep_all,
-              :cache => cache
+              id:       ident,
+              jsonpath: jsonpath,
+              keep_all: keep_all,
+              cache:    cache
             }
 
             instance = described_class.new(sequence_table, opts)
@@ -201,7 +200,7 @@ describe Alephant::Sequencer do
         end
       end
 
-      context "last_seen_id < sequence_id_from(msg)" do
+      context 'last_seen_id < sequence_id_from(msg)' do
         before(:each) do
           expect_any_instance_of(described_class).to receive(:get_last_seen).and_return(stubbed_last_seen)
 
@@ -214,7 +213,7 @@ describe Alephant::Sequencer do
           expect_any_instance_of(Dalli::Client).to receive(:set)
         end
 
-        it "should call set_last_seen(msg, last_seen_id)" do
+        it 'should call set_last_seen(msg, last_seen_id)' do
           expect_any_instance_of(described_class).to receive(:set_last_seen).with(message, stubbed_last_seen)
 
           expect(sequence_table).to receive(:sequence_exists)
@@ -223,18 +222,18 @@ describe Alephant::Sequencer do
         end
       end
 
-      context "values already in cache" do
+      context 'values already in cache' do
         before(:each) do
-          expect(message).to receive(:body).and_return("sequence_id" => 5)
+          expect(message).to receive(:body).and_return('sequence_id' => 5)
 
           expect_any_instance_of(Dalli::ElastiCache).to receive(:initialize)
           expect_any_instance_of(Dalli::ElastiCache).to receive(:client).and_return(Dalli::Client.new)
 
-          expect_any_instance_of(Dalli::Client).to receive(:get).twice.with("ident").and_return(stubbed_last_seen)
+          expect_any_instance_of(Dalli::Client).to receive(:get).twice.with('ident').and_return(stubbed_last_seen)
           expect_any_instance_of(Dalli::Client).to_not receive(:set)
         end
 
-        it "should read values from cache and not database" do
+        it 'should read values from cache and not database' do
           expect(sequence_table).to_not receive(:sequence_for)
           expect(sequence_table).to_not receive(:sequence_exists)
 
@@ -245,12 +244,12 @@ describe Alephant::Sequencer do
       end
     end
 
-    describe "#get_last_seen" do
-      subject (:instance) {
+    describe '#get_last_seen' do
+      subject (:instance) do
         described_class.new(sequence_table, opts)
-      }
+      end
 
-      it "returns sequence_table.sequence_for(ident)" do
+      it 'returns sequence_table.sequence_for(ident)' do
         expect_any_instance_of(Dalli::ElastiCache).to receive(:initialize)
         expect_any_instance_of(Dalli::ElastiCache).to receive(:client).and_return(Dalli::Client.new)
 
@@ -267,7 +266,7 @@ describe Alephant::Sequencer do
       end
     end
 
-    describe "#set_last_seen" do
+    describe '#set_last_seen' do
       before(:each) do
         expect(described_class).to receive(:sequence_id_from).and_return(last_seen)
 
@@ -278,11 +277,11 @@ describe Alephant::Sequencer do
         expect_any_instance_of(Dalli::Client).to receive(:set).twice
       end
 
-      subject (:instance) {
+      subject (:instance) do
         described_class.new(sequence_table, opts)
-      }
+      end
 
-      it "calls update_sequence_id(ident, last_seen)" do
+      it 'calls update_sequence_id(ident, last_seen)' do
         expect(sequence_table).to receive(:sequence_exists).twice
 
         expect(sequence_table).to receive(:update_sequence_id)
@@ -292,20 +291,20 @@ describe Alephant::Sequencer do
       end
     end
 
-    describe ".sequence_id_from" do
-      it "should return the id described by the set jsonpath" do
-        msg = Struct.new(:body).new("set_sequence_id" => 1)
+    describe '.sequence_id_from' do
+      it 'should return the id described by the set jsonpath' do
+        msg = Struct.new(:body).new('set_sequence_id' => 1)
 
-        expect(described_class.sequence_id_from(msg, "$.set_sequence_id")).to eq(1)
+        expect(described_class.sequence_id_from(msg, '$.set_sequence_id')).to eq(1)
       end
     end
 
-    describe "#sequential?" do
+    describe '#sequential?' do
       before(:each) do
         expect_any_instance_of(described_class).to receive(:get_last_seen).and_return(1)
 
         expect(data).to receive(:body)
-          .and_return("sequence_id" => id_value)
+          .and_return('sequence_id' => id_value)
 
         expect(sequence_table).to receive(:sequence_exists)
 
@@ -316,57 +315,57 @@ describe Alephant::Sequencer do
         expect_any_instance_of(Dalli::Client).to receive(:set)
       end
 
-      subject (:instance) {
+      subject (:instance) do
         described_class.new(sequence_table, opts)
-      }
+      end
 
       context "jsonpath = '$.sequence_id'" do
-        let(:jsonpath) { "$.sequence_id" }
+        let(:jsonpath) { '$.sequence_id' }
 
-        context "sequential" do
+        context 'sequential' do
           let(:id_value) { 2 }
 
-          it "is true" do
+          it 'is true' do
             expect(instance.sequential?(data)).to be
           end
         end
 
-        context "nonsequential" do
+        context 'nonsequential' do
           let(:id_value) { 0 }
 
-          it "is false" do
+          it 'is false' do
             expect(instance.sequential?(data)).to be false
           end
         end
       end
 
-      context "jsonpath = nil" do
-        let(:jsonpath) { "$.sequence_id" }
+      context 'jsonpath = nil' do
+        let(:jsonpath) { '$.sequence_id' }
 
-        context "sequential" do
+        context 'sequential' do
           let(:id_value) { 2 }
 
-          it "is true" do
+          it 'is true' do
             expect(instance.sequential?(data)).to be
           end
         end
 
-        context "nonsequential" do
+        context 'nonsequential' do
           let(:id_value) { 0 }
 
-          it "is false" do
+          it 'is false' do
             expect(instance.sequential?(data)).to be false
           end
         end
       end
     end
 
-    describe "#truncate!" do
-      subject (:instance) {
+    describe '#truncate!' do
+      subject (:instance) do
         described_class.new(sequence_table, opts)
-      }
+      end
 
-      it "verify SequenceTable#truncate!" do
+      it 'verify SequenceTable#truncate!' do
         expect_any_instance_of(Dalli::ElastiCache).to receive(:initialize)
         expect_any_instance_of(Dalli::ElastiCache).to receive(:client).and_return(Dalli::Client.new)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
-$: << File.join(File.dirname(__FILE__),"..", "lib")
+$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 
-require "pry"
-require "alephant/sequencer"
-require "alephant/support"
-
+require 'pry'
+require 'alephant/sequencer'
+require 'alephant/support'


### PR DESCRIPTION
Seeing this error in the logs when using the Vanilla Broker:
```
Alephant::SequenceCache::#initialize: No config endpoint, NullClient used
```

The issue is the keys are now symbols and the Sequencer uses strings. Changing this to match the Lookup functionality of allowing symbols and strings:
> https://github.com/BBC-News/alephant-lookup/blob/master/lib/alephant/lookup/lookup_cache.rb#L44-L58

The change is in this commit: https://github.com/BBC-News/alephant-sequencer/commit/0e9dcae8d3597f0c249193c821e3c6392b8228b7

The rest is updating .gitignore and rubocop'ing the codebase.