### PR TITLE
Update AWS SDK to V3

### DIFF
--- a/alephant-sequencer.gemspec
+++ b/alephant-sequencer.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = "alephant-sequencer"
   spec.version       = Alephant::Sequencer::VERSION
   spec.authors       = ["BBC News"]
-  spec.email         = ["FutureMediaNewsRubyGems@bbc.co.uk"]
+  spec.email         = ["D&ENewsFrameworksTeam@bbc.co.uk"]
   spec.summary       = %q{Adds sequencing functionality to Alephant.}
   spec.homepage      = ""
   spec.license       = "MIT"
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-remote"
   spec.add_development_dependency "pry-nav"
 
-  spec.add_runtime_dependency "aws-sdk", "~> 1.0"
+  spec.add_runtime_dependency "aws-sdk-dynamodb"
   spec.add_runtime_dependency "alephant-logger"
   spec.add_runtime_dependency "alephant-support"
   spec.add_runtime_dependency "jsonpath"

--- a/lib/alephant/sequencer/sequence_table.rb
+++ b/lib/alephant/sequencer/sequence_table.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require "aws-sdk-dynamodb"
 require 'thread'
 require 'timeout'
 
@@ -12,8 +12,10 @@ module Alephant
       attr_reader :table_name, :client
 
       def initialize(table_name)
+        options = {}
+        options.merge!({endpoint: ENV['AWS_DYNAMO_DB_ENDPOINT']}) if ENV['AWS_DYNAMO_DB_ENDPOINT']
         @mutex      = Mutex.new
-        @client     = AWS::DynamoDB::Client::V20120810.new
+        @client     = Aws::DynamoDB::Client.new(options)
         @table_name = table_name
       end
 
@@ -70,7 +72,7 @@ module Alephant
 
         dynamo_response
 
-      rescue AWS::DynamoDB::Errors::ConditionalCheckFailedException
+      rescue Aws::DynamoDB::Errors::ConditionalCheckFailedException
         logger.metric 'SequencerFailedConditionalChecks'
         logger.error(
           'event'                => 'DynamoDBConditionalCheckFailed',


### PR DESCRIPTION
Updates the AWS SDK to use version 3. Version 3 is module so this only requires the S3 module.

![](https://media2.giphy.com/media/VTcRJCMBD0PPa/giphy.gif)