### PR TITLE
Update sequencer update sequence logic

### DIFF
--- a/lib/alephant/sequencer/version.rb
+++ b/lib/alephant/sequencer/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Sequencer
-    VERSION = '3.1.0'.freeze
+    VERSION = '3.1.1'.freeze
   end
 end


### PR DESCRIPTION
It seems the older sequencer with V1 of the SDK wrote the sequence numbers as strings. The new version with the V3 SDK writes the sequence numbers as integers.

It seems the syntax we were using previously has since been deprecated.

A conditional update will either update the item if it exists and satisfies the criteria, such as a sequence number comparison, or it will add the item to the table if it does not exist. It seems the check if the key is null or not (we can now check if it exists) is redundant.