### PR TITLE
Remove dalli-elasticache gem

### DIFF
--- a/alephant-sequencer.gemspec
+++ b/alephant-sequencer.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "alephant-logger"
   spec.add_runtime_dependency "alephant-support"
   spec.add_runtime_dependency "jsonpath"
-  spec.add_runtime_dependency "dalli-elasticache"
+  spec.add_runtime_dependency "dalli"
 end

--- a/lib/alephant/sequencer/sequence_cache.rb
+++ b/lib/alephant/sequencer/sequence_cache.rb
@@ -1,4 +1,4 @@
-require 'dalli-elasticache'
+require 'dalli'
 require 'alephant/logger'
 
 module Alephant
@@ -18,8 +18,7 @@ module Alephant
           logger.metric 'NoConfigEndpoint'
           @client = NullClient.new
         else
-          @elasticache ||= ::Dalli::ElastiCache.new(config_endpoint, expires_in: ttl)
-          @client ||= @elasticache.client
+          @client ||= ::Dalli::Client.new(config_endpoint, expires_in: ttl)
         end
       end
 

--- a/lib/alephant/sequencer/version.rb
+++ b/lib/alephant/sequencer/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Sequencer
-    VERSION = '3.1.1'.freeze
+    VERSION = '3.2.0'.freeze
   end
 end


### PR DESCRIPTION
The dalli-elasticache gem has to potential to cause a blocking 60s timeout when trying to auto-discover elasticache endpoints. We are removing this wrapper in favour of simply using the Dalli client directly as the auto-discovery feature is no longer needed and the dalli-elasticache gem is unmaintained.

I have also refactored the tests to simplify the Dalli cache mocking